### PR TITLE
Add test to template output

### DIFF
--- a/resources/leiningen/new/protojure/README.md
+++ b/resources/leiningen/new/protojure/README.md
@@ -68,6 +68,10 @@ You should see output like the below in the repl after the 3rd command:
 
 ```
 
+## Running the tests
+
+No other prerequisite exists for running `lein test` other than having successfully run `make`
+
 ## Making this project your own:
 
 From here, a probable next step is adding your own `.proto` Protocol Buffer

--- a/resources/leiningen/new/protojure/project.clj
+++ b/resources/leiningen/new/protojure/project.clj
@@ -10,12 +10,16 @@
 
                  ;; -- PROTOC-GEN-CLOJURE --
                  [io.github.protojure/grpc-server "2.0.6"]
+                 [io.github.protojure/grpc-client "2.0.6"]
                  [io.github.protojure/google.protobuf "2.0.0"]
 
                  [ch.qos.logback/logback-classic "1.2.9"]
                  [org.slf4j/jul-to-slf4j "1.7.32"]
                  [org.slf4j/jcl-over-slf4j "1.7.32"]
-                 [org.slf4j/log4j-over-slf4j "1.7.32"]]
+                 [org.slf4j/log4j-over-slf4j "1.7.32"]
+
+                 [com.taoensso/timbre "4.10.0"]
+                 [com.fzakaria/slf4j-timbre "0.3.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "{{name}}.server/run-dev"]}

--- a/resources/leiningen/new/protojure/service_test.clj
+++ b/resources/leiningen/new/protojure/service_test.clj
@@ -1,0 +1,69 @@
+(ns {{sanitized}}.service-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as string]
+            [clojure.core.async :refer [<!! >!! <! >! go go-loop] :as async]
+            [promesa.core :as p]
+            [io.pedestal.http :as pedestal]
+            [io.pedestal.http.body-params :as body-params]
+            [io.pedestal.interceptor :refer [interceptor]]
+            [io.pedestal.interceptor.chain :refer [terminate]]
+            [protojure.pedestal.routes :as pedestal.routes]
+            [protojure.pedestal.core :as protojure.pedestal]
+            [protojure.grpc.client.providers.http2 :as grpc.http2]
+            [com.example.addressbook.Greeter.server :as greeter]
+            [com.example.addressbook.Greeter.client :as greeter-client]
+            [taoensso.timbre :as log]
+            [taoensso.timbre.appenders.core :as appenders]
+            [taoensso.timbre.tools.logging :refer [use-timbre]])
+  (:import [java.nio ByteBuffer])
+  (:refer-clojure :exclude [resolve]))
+
+(log/set-config! {:level :error
+                  :ns-whitelist ["protojure.*"]
+                  :appenders {:println (appenders/println-appender {:stream :auto})}})
+
+(use-timbre)
+
+(deftype Greeter []
+  greeter/Service
+  (Hello
+    [this { {:keys [name]} :grpc-params :as request}]
+    {:status 200
+     :body {:message (str "Hello, " name)}}))
+
+(def test-env (atom {}))
+
+(defn create-service []
+  (let [port (let [socket (java.net.ServerSocket. 0)]
+               (.close socket)
+               (.getLocalPort socket))
+        interceptors [(body-params/body-params)
+                      pedestal/html-body]
+        server-params {:env                      :prod
+                       ::pedestal/routes         (into #{} (concat interceptors
+                                                                   (pedestal.routes/->tablesyntax {:rpc-metadata greeter/rpc-metadata
+                                                                                                               :interceptors interceptors
+                                                                                                               :callback-context (Greeter.)})))
+                       ::pedestal/port           port
+
+                       ::pedestal/type           protojure.pedestal/config
+                       ::pedestal/chain-provider protojure.pedestal/provider}
+        client-params {:port port :idle-timeout -1}]
+    (let [server (-> (pedestal/create-server server-params)
+                   (pedestal/start))]
+      (swap! test-env assoc :port port :server server))))
+
+(defn destroy-service []
+  (swap! test-env update :server pedestal/stop))
+
+(defn wrap-service [test-fn]
+  (create-service)
+  (test-fn)
+  (destroy-service))
+
+(use-fixtures :each wrap-service)
+
+(deftest grpc-check
+  (testing "Check that a simple grpc call works end to end"
+    (is (= "Hello, John Doe"
+           (:message @(greeter-client/Hello @(grpc.http2/connect {:uri (str "http://localhost:" (:port @test-env))}) {:name "John Doe"}))))))

--- a/src/leiningen/new/protojure.clj
+++ b/src/leiningen/new/protojure.clj
@@ -21,4 +21,5 @@
              ["README.md" (render "README.md" data)]
              ["src/{{sanitized}}/server.clj" (render "server.clj" data)]
              ["src/{{sanitized}}/service.clj" (render "service.clj" data)]
+             ["test/{{sanitized}}/service_test.clj" (render "service_test.clj" data)]
              ["resources/addressbook.proto" (render "addressbook.proto" data)])))


### PR DESCRIPTION
Note we add timbre logging dependencies, which while somewhat opinionated, greatly eases consolidating and filtering log output

Signed-off-by: Matthew Rkiouak <mrkiouak@gmail.com>